### PR TITLE
PTSE 83 - Website Wrappers: commissions for price updates

### DIFF
--- a/Wrappers/clickandgo/converters/propertease_to_clickandgo.py
+++ b/Wrappers/clickandgo/converters/propertease_to_clickandgo.py
@@ -15,7 +15,7 @@ class ProperteaseToClickandgo:
         "free_wifi": "wifi_free",
         "parking_space": "parking",
     }
-    commission = 2 # percent
+    commission = 0.02
 
 
     @staticmethod
@@ -114,4 +114,4 @@ class ProperteaseToClickandgo:
 
     @staticmethod
     def convert_price(propertease_price: float, after_commission: bool) -> float:
-        return propertease_price / (1 - (ProperteaseToClickandgo.commission / 100)) if after_commission else propertease_price 
+        return propertease_price * (1 + ProperteaseToClickandgo.commission) if after_commission else propertease_price 

--- a/Wrappers/earthstayin/converters/propertease_to_earthstayin.py
+++ b/Wrappers/earthstayin/converters/propertease_to_earthstayin.py
@@ -15,7 +15,7 @@ class ProperteaseToEarthstayin:
         "free_wifi": "free_wifi",
         "parking_space": "car_parking",
     }
-    commission = 5 # percent
+    commission = 0.05
 
     @staticmethod
     def convert_property(propertease_property):
@@ -109,4 +109,4 @@ class ProperteaseToEarthstayin:
 
     @staticmethod
     def convert_price(propertease_price: float, after_commission: bool) -> float:
-        return propertease_price / (1 - (ProperteaseToEarthstayin.commission / 100)) if after_commission else propertease_price 
+        return propertease_price * (1 + ProperteaseToEarthstayin.commission) if after_commission else propertease_price 

--- a/Wrappers/zooking/converters/propertease_to_zooking.py
+++ b/Wrappers/zooking/converters/propertease_to_zooking.py
@@ -15,7 +15,7 @@ class ProperteaseToZooking:
         "free_wifi": "wifi",
         "parking_space": "open_parking",
     }
-    commission = 3 # percent
+    commission = 0.03
 
     @staticmethod
     def convert_property(propertease_property):
@@ -87,4 +87,4 @@ class ProperteaseToZooking:
     
     @staticmethod
     def convert_price(propertease_price: float, after_commission: bool) -> float:
-        return propertease_price / (1 - (ProperteaseToZooking.commission / 100)) if after_commission else propertease_price 
+        return propertease_price * (1 + ProperteaseToZooking.commission) if after_commission else propertease_price 


### PR DESCRIPTION
Added the possibility for a property owner to set his price after or before commission is taken.
If he sets his price as 200€, and sets "After commission", that means he will receive 200€ whenever a reservation is made. The price on the external services will be updated as `200 / (1 - commission)`.

Example: 
```
- Update price to 200€
- Commission of Zooking is 5%
- Price in zooking will be (200 / 0.95) = 210.52€, so that whenever a purchase is made, the property owner gets exactly 200€
```